### PR TITLE
Supports more 'proactive' semantic version mapping

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.0-RC.6", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.0-RC.7", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()
@@ -57,8 +57,8 @@ release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 java.settings.javaVersion = "17"
 javaTestNG.settings.javaVersion = "17"
 idea.settings.moduleMap = [
-    "org.savantbuild:savant-utils:2.0.0-RC.6"   : "savant-utils",
-    "org.savantbuild:savant-version:2.0.0-RC.6" : "savant-version"
+    "org.savantbuild:savant-utils:2.0.0-RC.6"  : "savant-utils",
+    "org.savantbuild:savant-version:2.0.0-RC.6": "savant-version"
 ]
 
 target(name: "clean", description: "Cleans the project") {

--- a/src/main/java/org/savantbuild/dep/DefaultDependencyService.java
+++ b/src/main/java/org/savantbuild/dep/DefaultDependencyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,7 @@ public class DefaultDependencyService implements DependencyService {
 
     Set<Dependency> seenAtLeastOnce = new HashSet<>();
 
-    graph.traverse(new Dependency(graph.root.id), false, null, (origin, destination, edgeValue, depth, isLast) -> {
+    graph.traverse(new Dependency(graph.root.id, graph.root.nonSemanticVersion), false, null, (origin, destination, edgeValue, depth, isLast) -> {
       List<Edge<Dependency, DependencyEdgeValue>> inboundEdges = graph.getInboundEdges(destination);
       boolean alreadyCheckedAllParents = inboundEdges.size() > 0 && inboundEdges.stream().allMatch((edge) -> artifacts.containsKey(edge.getOrigin().id));
       if (alreadyCheckedAllParents) {
@@ -269,7 +269,7 @@ public class DefaultDependencyService implements DependencyService {
                                                       .getValue();
 
     // Build the artifact for this node, save it in the Map and put it in the ArtifactGraph
-    ReifiedArtifact destinationArtifact = new ReifiedArtifact(destination.id, max, edgeValue.licenses);
+    ReifiedArtifact destinationArtifact = new ReifiedArtifact(destination.id, max, edgeValue.licenses, destination.nonSemanticVersion);
     artifacts.put(destination.id, destinationArtifact);
 
     significantInbound.forEach((edge) -> {
@@ -312,10 +312,10 @@ public class DefaultDependencyService implements DependencyService {
 
         // Create an edge using nodes so that we can be explicit
         DependencyEdgeValue edge = new DependencyEdgeValue(origin.version, dependency.version, type, amd.licenses);
-        graph.addEdge(new Dependency(origin.id), new Dependency(dependency.id), edge);
+        graph.addEdge(new Dependency(origin.id, origin.nonSemanticVersion), new Dependency(dependency.id, dependency.nonSemanticVersion), edge);
         if (dependency.skipCompatibilityCheck) {
           output.debugln("SKIPPING COMPATIBILITY CHECK for [%s]", dependency.id);
-          graph.skipCompatibilityCheck(dependency.id);
+          graph.skipCompatibilityCheck(dependency.id, dependency.nonSemanticVersion);
         }
 
         // If we have already recursed this artifact, skip it.

--- a/src/main/java/org/savantbuild/dep/domain/Artifact.java
+++ b/src/main/java/org/savantbuild/dep/domain/Artifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.savantbuild.domain.Version;
-
-import static java.util.Arrays.stream;
 
 /**
  * <p>
@@ -123,28 +121,9 @@ public class Artifact {
 
     this.nonSemanticVersion = nonSemanticVersion;
     this.skipCompatibilityCheck = skipCompatibilityCheck;
-
-    String[] parts = spec.split(":");
-    if (parts.length < 3) {
-      throw new IllegalArgumentException("Invalid artifact specification [" + spec + "]. It must have 3, 4, or 5 parts");
-    }
-
-    if (stream(parts).anyMatch(String::isEmpty)) {
-      throw new IllegalArgumentException("Invalid artifact specification [" + spec + "]. One of the parts is empty (i.e. foo::3.0");
-    }
-
-    if (parts.length == 3) {
-      id = new ArtifactID(parts[0], parts[1], parts[1], "jar");
-      version = new Version(parts[2]);
-    } else if (parts.length == 4) {
-      id = new ArtifactID(parts[0], parts[1], parts[1], parts[3]);
-      version = new Version(parts[2]);
-    } else if (parts.length == 5) {
-      id = new ArtifactID(parts[0], parts[1], parts[2], parts[4]);
-      version = new Version(parts[3]);
-    } else {
-      throw new IllegalArgumentException("Invalid artifact specification [" + spec + "]. It must have 3, 4, or 5 parts");
-    }
+    var artifactSpec = new ArtifactSpec(spec);
+    id = artifactSpec.id;
+    version = artifactSpec.version;
 
     if (exclusions != null) {
       this.exclusions = Collections.unmodifiableList(new ArrayList<>(exclusions));

--- a/src/main/java/org/savantbuild/dep/domain/ArtifactSpec.java
+++ b/src/main/java/org/savantbuild/dep/domain/ArtifactSpec.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.savantbuild.dep.domain;
+
+import org.savantbuild.domain.Version;
+
+import static java.util.Arrays.stream;
+
+public class ArtifactSpec {
+  public final ArtifactID id;
+
+  public final Version version;
+
+  public ArtifactSpec(String spec) {
+    this(spec, true);
+  }
+
+  public ArtifactSpec(String spec, boolean parseVersion) {
+    String[] parts = spec.split(":");
+    if (parts.length < 3) {
+      throw new IllegalArgumentException("Invalid artifact specification [" + spec + "]. It must have 3, 4, or 5 parts");
+    }
+
+    if (stream(parts).anyMatch(String::isEmpty)) {
+      throw new IllegalArgumentException("Invalid artifact specification [" + spec + "]. One of the parts is empty (i.e. foo::3.0");
+    }
+
+    String draftVersion;
+
+    if (parts.length == 3) {
+      id = new ArtifactID(parts[0], parts[1], parts[1], "jar");
+      draftVersion = parts[2];
+    } else if (parts.length == 4) {
+      id = new ArtifactID(parts[0], parts[1], parts[1], parts[3]);
+      draftVersion = parts[2];
+    } else if (parts.length == 5) {
+      id = new ArtifactID(parts[0], parts[1], parts[2], parts[4]);
+      draftVersion = parts[3];
+    } else {
+      throw new IllegalArgumentException("Invalid artifact specification [" + spec + "]. It must have 3, 4, or 5 parts");
+    }
+    version = parseVersion ? new Version(draftVersion) : null;
+  }
+}

--- a/src/main/java/org/savantbuild/dep/domain/ReifiedArtifact.java
+++ b/src/main/java/org/savantbuild/dep/domain/ReifiedArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,10 @@ public class ReifiedArtifact extends Artifact {
 
   public ReifiedArtifact(ArtifactID id, Version version, List<License> licenses) {
     this(id, version, null, Collections.emptyList(), licenses);
+  }
+
+  public ReifiedArtifact(ArtifactID id, Version version, List<License> licenses, String nonSemanticVersion) {
+    this(id, version, nonSemanticVersion, Collections.emptyList(), licenses);
   }
 
   public ReifiedArtifact(ArtifactID id, Version version, List<ArtifactID> exclusions, List<License> licenses) {

--- a/src/main/java/org/savantbuild/dep/graph/DependencyGraph.java
+++ b/src/main/java/org/savantbuild/dep/graph/DependencyGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,8 +58,8 @@ public class DependencyGraph extends HashGraph<Dependency, DependencyEdgeValue> 
     return result;
   }
 
-  public void skipCompatibilityCheck(ArtifactID id) {
-    HashNode<Dependency, DependencyEdgeValue> node = getNode(new Dependency(id));
+  public void skipCompatibilityCheck(ArtifactID id, String nonSemanticVersion) {
+    HashNode<Dependency, DependencyEdgeValue> node = getNode(new Dependency(id, nonSemanticVersion));
     node.value.skipCompatibilityCheck = true;
   }
 
@@ -73,7 +73,7 @@ public class DependencyGraph extends HashGraph<Dependency, DependencyEdgeValue> 
     build.append("digraph Dependencies {\n");
 
     Formatter formatter = new Formatter(build);
-    traverse(new Dependency(root.id), false, new SingleTraversalEdgeFilter<>(), (origin, destination, edge, depth, isLast) -> {
+    traverse(new Dependency(root.id, root.nonSemanticVersion), false, new SingleTraversalEdgeFilter<>(), (origin, destination, edge, depth, isLast) -> {
       formatter.format("  \"%s\" -> \"%s\" [label=\"%s\", headlabel=\"%s\", taillabel=\"%s\"];\n", origin, destination, edge, edge.dependentVersion, edge.dependencyVersion);
       return true;
     });
@@ -102,7 +102,7 @@ public class DependencyGraph extends HashGraph<Dependency, DependencyEdgeValue> 
    */
   public void versionCorrectTraversal(GraphConsumer<Dependency, DependencyEdgeValue> consumer) {
     super.traverse(
-        new Dependency(root.id),
+        new Dependency(root.id, root.nonSemanticVersion),
         false,
         (edge, traversedEdge) -> edge.getValue().dependentVersion.equals(traversedEdge.getValue().dependencyVersion),
         consumer
@@ -112,10 +112,13 @@ public class DependencyGraph extends HashGraph<Dependency, DependencyEdgeValue> 
   public static class Dependency {
     public final ArtifactID id;
 
+    public final String nonSemanticVersion;
+
     public boolean skipCompatibilityCheck;
 
-    public Dependency(ArtifactID id) {
+    public Dependency(ArtifactID id, String nonSemanticVersion) {
       this.id = id;
+      this.nonSemanticVersion = nonSemanticVersion;
     }
 
     @Override

--- a/src/main/java/org/savantbuild/dep/maven/MavenTools.java
+++ b/src/main/java/org/savantbuild/dep/maven/MavenTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,19 +249,16 @@ public class MavenTools {
   }
 
   private static Version determineVersion(POM pom, Map<String, Version> mappings) {
-    Version version;
-    try {
-      version = new Version(pom.version);
-    } catch (VersionException e) {
-      // Look up the mapping
-      String key = pom.toSpecification();
-      version = mappings.get(key);
-      if (version == null) {
-        throw new VersionException(String.format(VersionError, key));
-      }
+    String key = pom.toSpecification();
+    Version version = mappings.get(key);
+    if (version != null) {
+      return version;
     }
-
-    return version;
+    try {
+      return new Version(pom.version);
+    } catch (VersionException e) {
+      throw new VersionException(String.format(VersionError, key));
+    }
   }
 
   private static Element firstChild(Element root, String childName) {

--- a/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
+++ b/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
@@ -327,12 +327,12 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
 
     DependencyGraph actual = service.buildGraph(project, dependencies, workflow);
     assertEquals(actual, expected);
-    var artifactGraph = service.reduce(actual);
-    var badVer = artifactGraph.values()
-                              .stream()
-                              .filter(r -> r.id.name.equals("badver"))
-                              .findFirst()
-                              .get();
+    ArtifactGraph artifactGraph = service.reduce(actual);
+    ReifiedArtifact badVer = artifactGraph.values()
+                                          .stream()
+                                          .filter(r -> r.id.name.equals("badver"))
+                                          .findFirst()
+                                          .get();
     assertEquals(badVer.nonSemanticVersion, "1.0.0.Final");
   }
 
@@ -371,12 +371,12 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
 
     DependencyGraph actual = service.buildGraph(project, dependencies, workflow);
     assertEquals(actual, expected);
-    var artifactGraph = service.reduce(actual);
-    var badVer = artifactGraph.values()
-                              .stream()
-                              .filter(r -> r.id.name.equals("badver"))
-                              .findFirst()
-                              .get();
+    ArtifactGraph artifactGraph = service.reduce(actual);
+    ReifiedArtifact badVer = artifactGraph.values()
+                                          .stream()
+                                          .filter(r -> r.id.name.equals("badver"))
+                                          .findFirst()
+                                          .get();
     assertEquals(badVer.nonSemanticVersion, "1.0");
     // TODO: Resolve too?
   }

--- a/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
+++ b/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
@@ -150,20 +150,20 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
   @BeforeMethod
   public void beforeMethod() {
     goodGraph = new DependencyGraph(project);
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(intermediate.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2_2.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf3_3.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate.id, intermediate.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2.id, leaf2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2_2.id, leaf2_2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf3_3.id, leaf3_3.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
 
     goodReducedGraph = new ArtifactGraph(project);
     goodReducedGraph.addEdge(project, multipleVersions, "compile");
@@ -262,21 +262,21 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
   public void buildGraphWithExclusions() {
     // Override to add exclusions. Because the project AND the exclusions artifact both exclude leaf1 and leaf1_1, this prevents them from being included in the graph
     goodGraph = new DependencyGraph(project);
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(exclusions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(exclusions.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(exclusions.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2_2.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf3_3.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(exclusions.id, exclusions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(exclusions.id, exclusions.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(exclusions.id, exclusions.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2.id, leaf2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2_2.id, leaf2_2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf3_3.id, leaf3_3.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
     // Excluded
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
 
     dependencies = new Dependencies(
         new DependencyGroup("compile", true,
@@ -321,9 +321,9 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ArtifactID nonSemanticId = new ArtifactID("org.savantbuild.test:has-non-semantic-versioned-dep");
     ArtifactID badVerId = new ArtifactID("org.savantbuild.test:badver");
     DependencyGraph expected = new DependencyGraph(project);
-    expected.addEdge(new Dependency(project.id), new Dependency(nonSemanticId), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("GPLV2_0", null)));
-    expected.addEdge(new Dependency(nonSemanticId), new Dependency(badVerId), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Apache-2.0", null)));
-    expected.addEdge(new Dependency(badVerId), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Commercial", "Commercial license")));
+    expected.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(nonSemanticId, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("GPLV2_0", null)));
+    expected.addEdge(new Dependency(nonSemanticId, null), new Dependency(badVerId, "1.0.0.Final"), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Apache-2.0", null)));
+    expected.addEdge(new Dependency(badVerId, "1.0.0.Final"), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Commercial", "Commercial license")));
 
     DependencyGraph actual = service.buildGraph(project, dependencies, workflow);
     assertEquals(actual, expected);
@@ -365,9 +365,9 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ArtifactID nonSemanticId = new ArtifactID("org.savantbuild.test:has-non-semantic-versioned-dep-proactive");
     ArtifactID badVerId = new ArtifactID("org.savantbuild.test:badver");
     DependencyGraph expected = new DependencyGraph(project);
-    expected.addEdge(new Dependency(project.id), new Dependency(nonSemanticId), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("GPLV2_0", null)));
-    expected.addEdge(new Dependency(nonSemanticId), new Dependency(badVerId), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Apache-2.0", null)));
-    expected.addEdge(new Dependency(badVerId), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Commercial", "Commercial license")));
+    expected.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(nonSemanticId, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("GPLV2_0", null)));
+    expected.addEdge(new Dependency(nonSemanticId, null), new Dependency(badVerId, "1.0.0.Final"), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Apache-2.0", null)));
+    expected.addEdge(new Dependency(badVerId, "1.0.0.Final"), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.parse("Commercial", "Commercial license")));
 
     DependencyGraph actual = service.buildGraph(project, dependencies, workflow);
     assertEquals(actual, expected);
@@ -387,21 +387,21 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     // Override to add exclusions but notice that the exclusions are brought back in because the intermediate pulls leaf1 transitively back in through multipleVersions.
     // The only exclusion that survives is through intermediate's exclusion of leaf2_2 in the main project build file
     goodGraph = new DependencyGraph(project);
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(intermediate.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf3_3.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate.id, intermediate.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2.id, leaf2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf3_3.id, leaf3_3.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
     // Excluded
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2_2.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2_2.id, leaf2_2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
 
     dependencies = new Dependencies(
         new DependencyGroup("compile", true,
@@ -422,21 +422,21 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     // Override to add exclusions but notice that the exclusions are brought back in because the intermediate pulls leaf1 transitively back in through multipleVersions.
     // The only exclusion that survives is through intermediate's exclusion of leaf2_2 in the main project build file
     goodGraph = new DependencyGraph(project);
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(intermediate.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
-    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV1_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate.id, intermediate.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("ApacheV2_0")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2.id, leaf2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", License.Licenses.get("LGPLV2_1")));
+    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
     // Excluded
-//    goodGraph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
-//    goodGraph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
-//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2_2.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
-//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
-//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf3_3.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+//    goodGraph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", License.Licenses.get("ApacheV2_0")));
+//    goodGraph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", License.Licenses.get("ApacheV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", License.Licenses.get("GPLV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", License.Licenses.get("ApacheV2_0")));
+//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2_2.id, leaf2_2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("OtherNonDistributableOpenSource", "Open source")));
+//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License("Commercial", "Commercial license")));
+//    goodGraph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf3_3.id, leaf3_3.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", License.Licenses.get("ApacheV2_0")));
 
     dependencies = new Dependencies(
         new DependencyGroup("compile", true,
@@ -688,20 +688,20 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ReifiedArtifact multipleVersionsDifferentDeps = new ReifiedArtifact(new ArtifactID("org.savantbuild.test", "multiple-versions-different-dependencies", "multiple-versions-different-dependencies", "jar"), new Version("1.1.0"), new License());
 
     DependencyGraph graph = new DependencyGraph(project);
-    graph.addEdge(new Dependency(project.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(intermediate.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
-    graph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(integrationBuild.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf1_1.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf2_2.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf3_3.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate.id, intermediate.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
+    graph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf1.id, leaf1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.1.1-{integration}"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(integrationBuild.id, integrationBuild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.1.1-{integration}"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2.id, leaf2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf1_1.id, leaf1_1.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf2_2.id, leaf2_2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf3_3.id, leaf3_3.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "runtime", new License()));
 
     ArtifactGraph expected = new ArtifactGraph(project);
     expected.addEdge(project, multipleVersions, "compile");
@@ -750,15 +750,15 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ReifiedArtifact multipleVersionsDifferentDeps = new ReifiedArtifact(new ArtifactID("org.savantbuild.test", "multiple-versions-different-dependencies", "multiple-versions-different-dependencies", "jar"), new Version("1.1.0"), new License());
 
     DependencyGraph graph = new DependencyGraph(project);
-    graph.addEdge(new Dependency(project.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(intermediate.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
-    graph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(leaf.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate.id, intermediate.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
+    graph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf.id, leaf.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(leaf.id, leaf.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf.id, leaf.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf.id, leaf.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "runtime", new License()));
 
     ArtifactGraph expected = new ArtifactGraph(project);
     expected.addEdge(project, multipleVersions, "compile");
@@ -806,17 +806,17 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ReifiedArtifact multipleVersionsDifferentDeps = new ReifiedArtifact(new ArtifactID("org.savantbuild.test", "multiple-versions-different-dependencies", "multiple-versions-different-dependencies", "jar"), new Version("1.1.0"), new License());
 
     DependencyGraph graph = new DependencyGraph(project);
-    graph.addEdge(new Dependency(project.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(intermediate.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersions.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
-    graph.addEdge(new Dependency(intermediate.id), new Dependency(multipleVersionsDifferentDeps.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(intermediate2.id), new Dependency(leaf.id), new DependencyEdgeValue(new Version("2.0.0"), new Version("2.0.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(intermediate2.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersions.id), new Dependency(intermediate2.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(intermediate2.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.0.0"), "runtime", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(intermediate2.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id), new Dependency(leaf.id), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate.id, intermediate.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
+    graph.addEdge(new Dependency(intermediate.id, intermediate.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(intermediate2.id, intermediate2.nonSemanticVersion), new Dependency(leaf.id, leaf.nonSemanticVersion), new DependencyEdgeValue(new Version("2.0.0"), new Version("2.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(intermediate2.id, intermediate2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersions.id, multipleVersions.nonSemanticVersion), new Dependency(intermediate2.id, intermediate2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(intermediate2.id, intermediate2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.0.0"), "runtime", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(intermediate2.id, intermediate2.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(multipleVersionsDifferentDeps.id, multipleVersionsDifferentDeps.nonSemanticVersion), new Dependency(leaf.id, leaf.nonSemanticVersion), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
 
     ArtifactGraph expected = new ArtifactGraph(project);
     expected.addEdge(project, multipleVersions, "compile");
@@ -863,19 +863,19 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ArtifactID multipleVersionsDifferentDeps = new ArtifactID("org.savantbuild.test", "multiple-versions-different-dependencies", "multiple-versions-different-dependencies", "jar");
 
     DependencyGraph incompatible = new DependencyGraph(project);
-    incompatible.addEdge(new Dependency(project.id), new Dependency(multipleVersions), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(project.id), new Dependency(intermediate), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(intermediate), new Dependency(multipleVersions), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(intermediate), new Dependency(multipleVersionsDifferentDeps), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(multipleVersions), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(multipleVersions), new Dependency(leaf), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps), new Dependency(leaf), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(intermediate, null), new Dependency(multipleVersions, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(intermediate, null), new Dependency(multipleVersionsDifferentDeps, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(multipleVersions, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(multipleVersions, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
 
     // Add the skip node
-    incompatible.addEdge(new Dependency(project.id), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.0.0"), "runtime", new License()));
-    incompatible.skipCompatibilityCheck(leaf);
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.0.0"), "runtime", new License()));
+    incompatible.skipCompatibilityCheck(leaf, null);
 
     ReifiedArtifact intermediateArtifact = new ReifiedArtifact(intermediate, new Version("1.0.0"), new License());
     ReifiedArtifact multipleVersionsArtifact = new ReifiedArtifact(multipleVersions, new Version("1.1.0"), new License());
@@ -915,9 +915,9 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ArtifactID intermediate = new ArtifactID("org.savantbuild.test", "intermediate", "intermediate", "jar");
 
     DependencyGraph incompatible = new DependencyGraph(project);
-    incompatible.addEdge(new Dependency(project.id), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(project.id), new Dependency(intermediate), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(intermediate), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(intermediate, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.0.0"), "compile", new License()));
 
     try {
       service.reduce(incompatible);
@@ -960,15 +960,15 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ArtifactID multipleVersionsDifferentDeps = new ArtifactID("org.savantbuild.test", "multiple-versions-different-dependencies", "multiple-versions-different-dependencies", "jar");
 
     DependencyGraph incompatible = new DependencyGraph(project);
-    incompatible.addEdge(new Dependency(project.id), new Dependency(multipleVersions), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(project.id), new Dependency(intermediate), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(project.id), new Dependency(multipleVersionsDifferentDeps), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(intermediate), new Dependency(multipleVersions), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(intermediate), new Dependency(multipleVersionsDifferentDeps), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(multipleVersions), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(multipleVersions), new Dependency(leaf), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
-    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
-    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps), new Dependency(leaf), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersions, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(intermediate, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(multipleVersionsDifferentDeps, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(intermediate, null), new Dependency(multipleVersions, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(intermediate, null), new Dependency(multipleVersionsDifferentDeps, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(multipleVersions, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(multipleVersions, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.1.0"), new Version("1.0.0"), "compile", new License()));
+    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "runtime", new License()));
+    incompatible.addEdge(new Dependency(multipleVersionsDifferentDeps, null), new Dependency(leaf, null), new DependencyEdgeValue(new Version("1.1.0"), new Version("2.0.0"), "compile", new License()));
 
     try {
       service.reduce(incompatible);
@@ -1007,12 +1007,12 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
     ReifiedArtifact d = new ReifiedArtifact(new ArtifactID("org.savantbuild.test", "d", "d", "jar"), new Version("1.1.0"), new License());
 
     DependencyGraph graph = new DependencyGraph(project);
-    graph.addEdge(new Dependency(project.id), new Dependency(a.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(b.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
-    graph.addEdge(new Dependency(project.id), new Dependency(c.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(a.id), new Dependency(aChild.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(b.id), new Dependency(d.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
-    graph.addEdge(new Dependency(d.id), new Dependency(a.id), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(a.id, a.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(b.id, b.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.1.0"), "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(c.id, c.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(a.id, a.nonSemanticVersion), new Dependency(aChild.id, aChild.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(b.id, b.nonSemanticVersion), new Dependency(d.id, d.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
+    graph.addEdge(new Dependency(d.id, d.nonSemanticVersion), new Dependency(a.id, a.nonSemanticVersion), new DependencyEdgeValue(new Version("1.0.0"), new Version("1.0.0"), "compile", new License()));
 
     ArtifactGraph expected = new ArtifactGraph(project);
     expected.addEdge(project, a, "compile");
@@ -1188,7 +1188,7 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
   private DependencyGraph makeSimpleGraph(String dependency) {
     DependencyGraph graph = new DependencyGraph(project);
     Artifact artifact = new Artifact(dependency);
-    graph.addEdge(new Dependency(project.id), new Dependency(artifact.id), new DependencyEdgeValue(project.version, artifact.version, "compile", new License()));
+    graph.addEdge(new Dependency(project.id, project.nonSemanticVersion), new Dependency(artifact.id, artifact.nonSemanticVersion), new DependencyEdgeValue(project.version, artifact.version, "compile", new License()));
     return graph;
   }
 

--- a/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
+++ b/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
@@ -875,7 +875,7 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
 
     // Add the skip node
     incompatible.addEdge(new Dependency(project.id), new Dependency(leaf), new DependencyEdgeValue(new Version("1.0.0"), new Version("2.0.0"), "runtime", new License()));
-    incompatible.skipCompatibilityCheck(leaf, null);
+    incompatible.skipCompatibilityCheck(leaf);
 
     ReifiedArtifact intermediateArtifact = new ReifiedArtifact(intermediate, new Version("1.0.0"), new License());
     ReifiedArtifact multipleVersionsArtifact = new ReifiedArtifact(multipleVersions, new Version("1.1.0"), new License());

--- a/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
+++ b/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
@@ -327,6 +327,13 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
 
     DependencyGraph actual = service.buildGraph(project, dependencies, workflow);
     assertEquals(actual, expected);
+    var artifactGraph = service.reduce(actual);
+    var badVer = artifactGraph.values()
+                              .stream()
+                              .filter(r -> r.id.name.equals("badver"))
+                              .findFirst()
+                              .get();
+    assertEquals(badVer.nonSemanticVersion, "1.0.0.Final");
   }
 
   @Test
@@ -364,7 +371,14 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
 
     DependencyGraph actual = service.buildGraph(project, dependencies, workflow);
     assertEquals(actual, expected);
-    fail("finish/write the test");
+    var artifactGraph = service.reduce(actual);
+    var badVer = artifactGraph.values()
+                              .stream()
+                              .filter(r -> r.id.name.equals("badver"))
+                              .findFirst()
+                              .get();
+    assertEquals(badVer.nonSemanticVersion, "1.0");
+    // TODO: Resolve too?
   }
 
 

--- a/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
+++ b/src/test/java/org/savantbuild/dep/DefaultDependencyServiceTest.java
@@ -337,7 +337,7 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
   }
 
   @Test
-  public void buildGraphWithNonSemanticVersions_proactive() {
+  public void buildGraphWithNonSemanticVersionsProactive() {
 //    output.enableDebug();
 
     dependencies = new Dependencies(
@@ -378,7 +378,6 @@ public class DefaultDependencyServiceTest extends BaseUnitTest {
                                           .findFirst()
                                           .get();
     assertEquals(badVer.nonSemanticVersion, "1.0");
-    // TODO: Resolve too?
   }
 
 

--- a/src/test/java/org/savantbuild/dep/graph/DependencyGraphTest.java
+++ b/src/test/java/org/savantbuild/dep/graph/DependencyGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,16 +38,16 @@ public class DependencyGraphTest extends BaseUnitTest {
     ReifiedArtifact four = new ReifiedArtifact("group:project:artifact4:1.0:jar", new License());
 
     DependencyGraph graph = new DependencyGraph(one);
-    graph.addEdge(new Dependency(one.id), new Dependency(two.id), new DependencyEdgeValue(one.version, two.version, "compile", new License()));
-    graph.addEdge(new Dependency(one.id), new Dependency(three.id), new DependencyEdgeValue(one.version, three.version, "compile", new License()));
-    graph.addEdge(new Dependency(two.id), new Dependency(four.id), new DependencyEdgeValue(two.version, four.version, "compile", new License()));
-    graph.addEdge(new Dependency(three.id), new Dependency(four.id), new DependencyEdgeValue(three.version, four.version, "compile", new License()));
+    graph.addEdge(new Dependency(one.id, one.nonSemanticVersion), new Dependency(two.id, two.nonSemanticVersion), new DependencyEdgeValue(one.version, two.version, "compile", new License()));
+    graph.addEdge(new Dependency(one.id, one.nonSemanticVersion), new Dependency(three.id, three.nonSemanticVersion), new DependencyEdgeValue(one.version, three.version, "compile", new License()));
+    graph.addEdge(new Dependency(two.id, two.nonSemanticVersion), new Dependency(four.id, four.nonSemanticVersion), new DependencyEdgeValue(two.version, four.version, "compile", new License()));
+    graph.addEdge(new Dependency(three.id, three.nonSemanticVersion), new Dependency(four.id, four.nonSemanticVersion), new DependencyEdgeValue(three.version, four.version, "compile", new License()));
 
     DependencyGraph graph2 = new DependencyGraph(one);
-    graph2.addEdge(new Dependency(three.id), new Dependency(four.id), new DependencyEdgeValue(three.version, four.version, "compile", new License()));
-    graph2.addEdge(new Dependency(two.id), new Dependency(four.id), new DependencyEdgeValue(two.version, four.version, "compile", new License()));
-    graph2.addEdge(new Dependency(one.id), new Dependency(three.id), new DependencyEdgeValue(one.version, three.version, "compile", new License()));
-    graph2.addEdge(new Dependency(one.id), new Dependency(two.id), new DependencyEdgeValue(one.version, two.version, "compile", new License()));
+    graph2.addEdge(new Dependency(three.id, three.nonSemanticVersion), new Dependency(four.id, four.nonSemanticVersion), new DependencyEdgeValue(three.version, four.version, "compile", new License()));
+    graph2.addEdge(new Dependency(two.id, two.nonSemanticVersion), new Dependency(four.id, four.nonSemanticVersion), new DependencyEdgeValue(two.version, four.version, "compile", new License()));
+    graph2.addEdge(new Dependency(one.id, one.nonSemanticVersion), new Dependency(three.id, three.nonSemanticVersion), new DependencyEdgeValue(one.version, three.version, "compile", new License()));
+    graph2.addEdge(new Dependency(one.id, one.nonSemanticVersion), new Dependency(two.id, two.nonSemanticVersion), new DependencyEdgeValue(one.version, two.version, "compile", new License()));
 
     assertEquals(graph, graph2);
   }
@@ -61,10 +61,10 @@ public class DependencyGraphTest extends BaseUnitTest {
     ReifiedArtifact four = new ReifiedArtifact("group:project:artifact4:1.0:jar", new License());
 
     DependencyGraph graph = new DependencyGraph(root);
-    graph.addEdge(new Dependency(root.id), new Dependency(one.id), new DependencyEdgeValue(root.version, one.version, "compile", new License()));
-    graph.addEdge(new Dependency(root.id), new Dependency(two.id), new DependencyEdgeValue(root.version, two.version, "compile", new License()));
-    graph.addEdge(new Dependency(one.id), new Dependency(three.id), new DependencyEdgeValue(one.version, three.version, "compile", new License()));
-    graph.addEdge(new Dependency(two.id), new Dependency(four.id), new DependencyEdgeValue(two.version, four.version, "compile", new License()));
+    graph.addEdge(new Dependency(root.id, root.nonSemanticVersion), new Dependency(one.id, one.nonSemanticVersion), new DependencyEdgeValue(root.version, one.version, "compile", new License()));
+    graph.addEdge(new Dependency(root.id, root.nonSemanticVersion), new Dependency(two.id, two.nonSemanticVersion), new DependencyEdgeValue(root.version, two.version, "compile", new License()));
+    graph.addEdge(new Dependency(one.id, one.nonSemanticVersion), new Dependency(three.id, three.nonSemanticVersion), new DependencyEdgeValue(one.version, three.version, "compile", new License()));
+    graph.addEdge(new Dependency(two.id, two.nonSemanticVersion), new Dependency(four.id, four.nonSemanticVersion), new DependencyEdgeValue(two.version, four.version, "compile", new License()));
 
     ArtifactID[] path1 = new ArtifactID[2];
     ArtifactID[] path2 = new ArtifactID[2];

--- a/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
+++ b/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,18 @@ package org.savantbuild.dep.maven;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
 import org.savantbuild.dep.BaseUnitTest;
 import org.savantbuild.dep.domain.Artifact;
-import org.savantbuild.dep.domain.ArtifactID;
 import org.savantbuild.dep.domain.Dependencies;
 import org.savantbuild.dep.domain.DependencyGroup;
+import org.savantbuild.domain.Version;
 import org.savantbuild.output.SystemOutOutput;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
-import static org.testng.Assert.fail;
 
 /**
  * Tests the Maven malarky.
@@ -37,6 +37,23 @@ import static org.testng.Assert.fail;
  * @author Brian Pontarelli
  */
 public class MavenToolsTest extends BaseUnitTest {
+  private static POM parseGroovyJsonPOM() {
+    POM pom = MavenTools.parsePOM(Paths.get("../savant-dependency-management/src/test/resources/groovy-json-4.0.6.pom"), new SystemOutOutput(true));
+    assertEquals(pom.group, "org.apache.groovy");
+    assertEquals(pom.id, "groovy-json");
+    assertEquals(pom.name, "Apache Groovy");
+    assertEquals(pom.version, "4.0.6");
+    assertNull(pom.parentGroup);
+    assertNull(pom.parentId);
+    assertNull(pom.parentVersion);
+    assertEquals(pom.dependencies, Arrays.asList(
+            new MavenDependency("org.apache.groovy", "groovy", "4.0.6", "compile")
+        )
+    );
+    assertEquals(pom.licenses, Collections.singletonList(new MavenLicense("repo", "The Apache Software License, Version 2.0", "http://www.apache.org/licenses/LICENSE-2.0.txt")));
+    return pom;
+  }
+
   @Test
   public void parse() {
     POM pom = MavenTools.parsePOM(Paths.get("../savant-dependency-management/src/test/resources/groovy-4.0.5.pom"), new SystemOutOutput(true));
@@ -65,21 +82,47 @@ public class MavenToolsTest extends BaseUnitTest {
 
   @Test
   public void parse_required() {
-    POM pom = MavenTools.parsePOM(Paths.get("../savant-dependency-management/src/test/resources/groovy-json-4.0.6.pom"), new SystemOutOutput(true));
-    assertEquals(pom.group, "org.apache.groovy");
-    assertEquals(pom.id, "groovy-json");
-    assertEquals(pom.name, "Apache Groovy");
-    assertEquals(pom.version, "4.0.6");
-    assertNull(pom.parentGroup);
-    assertNull(pom.parentId);
-    assertNull(pom.parentVersion);
-    assertEquals(pom.dependencies, Arrays.asList(
-            new MavenDependency("org.apache.groovy", "groovy", "4.0.6", "compile")
-        )
-    );
-    assertEquals(pom.licenses, Collections.singletonList(new MavenLicense("repo", "The Apache Software License, Version 2.0", "http://www.apache.org/licenses/LICENSE-2.0.txt")));
+    // arrange
+    POM pom = parseGroovyJsonPOM();
 
+    // act
     Dependencies dependencies = MavenTools.toSavantDependencies(pom, Collections.emptyMap());
+
+    // assert
+    var expectedArtifact = new Artifact("org.apache.groovy:groovy:4.0.6");
+    var expectedDependencyGroup = new DependencyGroup("compile", true, expectedArtifact);
+    assertEquals(dependencies,
+        new Dependencies(expectedDependencyGroup));
+  }
+
+  @Test
+  public void parse_version_remapped_maven_causes_exception() {
+    // arrange
+    POM pom = parseGroovyJsonPOM();
+    pom.dependencies.get(0).version = "4.0.heydude";
+    var mappings = Map.of("org.apache.groovy:groovy:4.0.heydude", new Version("4.0.6"));
+
+    // act
+    Dependencies dependencies = MavenTools.toSavantDependencies(pom, mappings);
+
+    // assert
+    var expectedArtifact = new Artifact("org.apache.groovy:groovy:4.0.6");
+    var expectedDependencyGroup = new DependencyGroup("compile", true, expectedArtifact);
+    assertEquals(dependencies,
+        new Dependencies(expectedDependencyGroup));
+  }
+
+  @Test
+  public void parse_version_remapped_maven_not_causes_exception() {
+    // arrange
+    POM pom = parseGroovyJsonPOM();
+    pom.dependencies.get(0).version = "4.0";
+    var mappings = Map.of("org.apache.groovy:groovy:4.0", new Version("4.0.6"));
+
+    // act
+    Dependencies dependencies = MavenTools.toSavantDependencies(pom, mappings);
+
+    // assert
     var expectedArtifact = new Artifact("org.apache.groovy:groovy:4.0.6");
     var expectedDependencyGroup = new DependencyGroup("compile", true, expectedArtifact);
     assertEquals(dependencies,

--- a/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
+++ b/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
@@ -20,12 +20,16 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.savantbuild.dep.BaseUnitTest;
+import org.savantbuild.dep.domain.Artifact;
+import org.savantbuild.dep.domain.ArtifactID;
 import org.savantbuild.dep.domain.Dependencies;
+import org.savantbuild.dep.domain.DependencyGroup;
 import org.savantbuild.output.SystemOutOutput;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
 
 /**
  * Tests the Maven malarky.
@@ -57,5 +61,28 @@ public class MavenToolsTest extends BaseUnitTest {
     // Everything is optional
     Dependencies dependencies = MavenTools.toSavantDependencies(pom, Collections.emptyMap());
     assertEquals(dependencies, new Dependencies());
+  }
+
+  @Test
+  public void parse_required() {
+    POM pom = MavenTools.parsePOM(Paths.get("../savant-dependency-management/src/test/resources/groovy-json-4.0.6.pom"), new SystemOutOutput(true));
+    assertEquals(pom.group, "org.apache.groovy");
+    assertEquals(pom.id, "groovy-json");
+    assertEquals(pom.name, "Apache Groovy");
+    assertEquals(pom.version, "4.0.6");
+    assertNull(pom.parentGroup);
+    assertNull(pom.parentId);
+    assertNull(pom.parentVersion);
+    assertEquals(pom.dependencies, Arrays.asList(
+            new MavenDependency("org.apache.groovy", "groovy", "4.0.6", "compile")
+        )
+    );
+    assertEquals(pom.licenses, Collections.singletonList(new MavenLicense("repo", "The Apache Software License, Version 2.0", "http://www.apache.org/licenses/LICENSE-2.0.txt")));
+
+    Dependencies dependencies = MavenTools.toSavantDependencies(pom, Collections.emptyMap());
+    var expectedArtifact = new Artifact("org.apache.groovy:groovy:4.0.6");
+    var expectedDependencyGroup = new DependencyGroup("compile", true, expectedArtifact);
+    assertEquals(dependencies,
+        new Dependencies(expectedDependencyGroup));
   }
 }

--- a/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
+++ b/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
@@ -81,7 +81,7 @@ public class MavenToolsTest extends BaseUnitTest {
   }
 
   @Test
-  public void parse_required() {
+  public void parseRequired() {
     // arrange
     POM pom = parseGroovyJsonPOM();
 
@@ -96,7 +96,7 @@ public class MavenToolsTest extends BaseUnitTest {
   }
 
   @Test
-  public void parse_version_remapped_maven_causes_version_exception() {
+  public void parseVersionRemappedMavenCausesVersionException() {
     // arrange
     POM pom = parseGroovyJsonPOM();
     pom.dependencies.get(0).version = "4.0.heydude";
@@ -113,7 +113,7 @@ public class MavenToolsTest extends BaseUnitTest {
   }
 
   @Test
-  public void parse_version_remapped_maven_not_causes_exception() {
+  public void parseVersionRemappedMavenNotCausesException() {
     // arrange
     POM pom = parseGroovyJsonPOM();
     pom.dependencies.get(0).version = "4.0";

--- a/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
+++ b/src/test/java/org/savantbuild/dep/maven/MavenToolsTest.java
@@ -96,7 +96,7 @@ public class MavenToolsTest extends BaseUnitTest {
   }
 
   @Test
-  public void parse_version_remapped_maven_causes_exception() {
+  public void parse_version_remapped_maven_causes_version_exception() {
     // arrange
     POM pom = parseGroovyJsonPOM();
     pom.dependencies.get(0).version = "4.0.heydude";

--- a/src/test/java/org/savantbuild/dep/xml/ArtifactToolsTest.java
+++ b/src/test/java/org/savantbuild/dep/xml/ArtifactToolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class ArtifactToolsTest extends BaseUnitTest {
         new ArtifactID("org.example", "exclude-3", "exclude-4", "zip")
     ));
 
-    assertEquals(amd.dependencies.groups.get("compile").dependencies.size(), 3);
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.size(), 4);
     assertEquals(amd.dependencies.groups.get("compile").name, "compile");
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(0).id.group, "org.example.test");
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(0).id.project, "test-project3");
@@ -90,6 +90,14 @@ public class ArtifactToolsTest extends BaseUnitTest {
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(2).version, new Version("1.0.0"));
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(2).nonSemanticVersion, "1.0.0.Final");
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(2).id.type, "jar");
+
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).id.group, "org.example.test");
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).id.project, "badver");
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).id.name, "badverproactive");
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).version, new Version("1.0.0"));
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).nonSemanticVersion, "1.0");
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).id.type, "jar");
+    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).getArtifactFile(), "foo");
   }
 
   /**

--- a/src/test/java/org/savantbuild/dep/xml/ArtifactToolsTest.java
+++ b/src/test/java/org/savantbuild/dep/xml/ArtifactToolsTest.java
@@ -97,7 +97,6 @@ public class ArtifactToolsTest extends BaseUnitTest {
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).version, new Version("1.0.0"));
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).nonSemanticVersion, "1.0");
     assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).id.type, "jar");
-    assertEquals(amd.dependencies.groups.get("compile").dependencies.get(3).getArtifactFile(), "foo");
   }
 
   /**

--- a/src/test/resources/amd.xml
+++ b/src/test/resources/amd.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+  ~ Copyright (c) 2024, Inversoft Inc., All Rights Reserved
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 <artifact-meta-data>
   <license type="ApacheV2_0"/>
   <license type="BSD_2_Clause">
-<![CDATA[Override the BSD license.]]>
+    <![CDATA[Override the BSD license.]]>
   </license>
   <dependencies>
     <dependency-group name="runtime">
@@ -31,6 +31,7 @@
       <dependency group="org.example.test" project="test-project3" name="test-project3" version="3.0" type="jar"/>
       <dependency group="org.example.test" project="test-project4" name="test-project4" version="4.0" type="jar"/>
       <dependency group="org.example.test" project="badver" name="badver" version="1.0.0.Final" type="jar"/>
+      <dependency group="org.example.test" project="badver" name="badverproactive" version="1.0" type="jar"/>
     </dependency-group>
   </dependencies>
 </artifact-meta-data>

--- a/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.jar
+++ b/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.jar
@@ -1,0 +1,1 @@
+This is an artifact that I can MD5 test

--- a/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.jar.md5
+++ b/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.jar.md5
@@ -1,0 +1,1 @@
+fc343a0e691e74133d3f9a8d45a57c40  badver-1.0.jar

--- a/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.pom
+++ b/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.pom
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  ~ either express or implied. See the License for the specific
+  ~ language governing permissions and limitations under the License.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.savantbuild.test</groupId>
+  <artifactId>badver</artifactId>
+  <version>1.0</version>
+  <name>Bad Version</name>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <dependencies>
+    <dependency>
+      <groupId>org.savantbuild.test</groupId>
+      <artifactId>leaf1</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.pom.md5
+++ b/test-deps/maven/org/savantbuild/test/badver/1.0/badver-1.0.pom.md5
@@ -1,0 +1,1 @@
+a4d9946e9babe28f4ddd7c12fd5e0078  badver-1.0.pom

--- a/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar
+++ b/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar
@@ -1,0 +1,1 @@
+This is an artifact that I can MD5 test

--- a/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar.amd
+++ b/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar.amd
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright (c) 2001-2013, Inversoft, All Rights Reserved
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+  ~ either express or implied. See the License for the specific
+  ~ language governing permissions and limitations under the License.
+  -->
+<artifact-meta-data>
+  <license type="GPLV2_0"/>
+  <dependencies>
+    <dependency-group name="compile">
+      <dependency group="org.savantbuild.test" project="badver" name="badver" version="1.0" type="jar"/>
+    </dependency-group>
+  </dependencies>
+</artifact-meta-data>

--- a/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar.amd.md5
+++ b/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar.amd.md5
@@ -1,0 +1,1 @@
+a077e61baa8ca7f13e816ef1f2bca50e  has-non-semantic-versioned-dep-proactive-1.0.0.jar.amd

--- a/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar.md5
+++ b/test-deps/savant/org/savantbuild/test/has-non-semantic-versioned-dep-proactive/1.0.0/has-non-semantic-versioned-dep-proactive-1.0.0.jar.md5
@@ -1,0 +1,1 @@
+fc343a0e691e74133d3f9a8d45a57c40  has-non-semantic-versioned-dep-proactive-1.0.0.jar


### PR DESCRIPTION
Currently Savant only uses semantic version mappings if version parsing throws an exception.

This change modifies it to use version mappings even if no exception is thrown, in particular to cover 1.0.0 vs. 1.0 cases.

This mainly meant using the mapping in `MavenTools` more proactively and then ensuring `ReifiedArtifact` had the non semantic version available to do the alternate fetch in `Workflow.fetchArtifact` that was already there, but that only works if `artifact.nonSemanticVersion` is available.

NOTE: I did not make the mapping check in `src/main/java/org/savantbuild/dep/xml/ArtifactTools.java` more proactive, because the code already handles converting `1.0` to `1.0.0` when it calls the `Version` constructor and it already holds on to `dependencyNonSemanticVersion`.

This also sets the stage for a Savant core change