### PR TITLE
Merge wied03/savant_2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build
 *.neg
 .savant
+# Fetched/generated deps that come from idea-plugin tests
+test-deps/savant/org/slf4j/slf4j-api

--- a/build.savant
+++ b/build.savant
@@ -47,11 +47,11 @@ project(group: "org.savantbuild", name: "savant-dependency-management", version:
 }
 
 // Plugins
-dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.6")
-java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.6")
-javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.6")
-idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.6")
-release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
+def dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.6")
+def java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.6")
+def javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.6")
+def idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
+def release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 
 // Plugin settings
 java.settings.javaVersion = "17"

--- a/build.savant
+++ b/build.savant
@@ -48,11 +48,11 @@ project(group: "org.savantbuild", name: "savant-dependency-management", version:
 }
 
 // Plugins
-def dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.7")
-def java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.6")
-def javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.6")
-def idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
-def release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
+dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.7")
+java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.6")
+javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.6")
+idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
+release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 
 // Plugin settings
 java.settings.javaVersion = "17"

--- a/build.savant
+++ b/build.savant
@@ -58,8 +58,8 @@ release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 java.settings.javaVersion = "17"
 javaTestNG.settings.javaVersion = "17"
 idea.settings.moduleMap = [
-    ("org.savantbuild:savant-utils:${savantVersion}".toString())  : "savant-utils",
-    ("org.savantbuild:savant-version:${savantVersion}".toString()): "savant-version"
+    "org.savantbuild:savant-utils:${savantVersion}"  : "savant-utils",
+    "org.savantbuild:savant-version:${savantVersion}": "savant-version"
 ]
 
 target(name: "clean", description: "Cleans the project") {

--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.1", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.0", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.1", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/build.savant
+++ b/build.savant
@@ -47,7 +47,7 @@ project(group: "org.savantbuild", name: "savant-dependency-management", version:
 }
 
 // Plugins
-def dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.6")
+def dependency = loadPlugin(id: "org.savantbuild.plugin:dependency:2.0.0-RC.7")
 def java = loadPlugin(id: "org.savantbuild.plugin:java:2.0.0-RC.6")
 def javaTestNG = loadPlugin(id: "org.savantbuild.plugin:java-testng:2.0.0-RC.6")
 def idea = loadPlugin(id: "org.savantbuild.plugin:idea:2.0.0-RC.7")
@@ -57,8 +57,8 @@ def release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 java.settings.javaVersion = "17"
 javaTestNG.settings.javaVersion = "17"
 idea.settings.moduleMap = [
-    "org.savantbuild:savant-utils:2.0.0-RC.6"  : "savant-utils",
-    "org.savantbuild:savant-version:2.0.0-RC.6": "savant-version"
+    "org.savantbuild:savant-utils:2.0.0-RC.7"  : "savant-utils",
+    "org.savantbuild:savant-version:2.0.0-RC.7": "savant-version"
 ]
 
 target(name: "clean", description: "Cleans the project") {

--- a/build.savant
+++ b/build.savant
@@ -13,6 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
+def savantVersion = "2.0.0-{integration}"
 project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
@@ -33,8 +34,8 @@ project(group: "org.savantbuild", name: "savant-dependency-management", version:
       dependency(id: "com.fasterxml.jackson.core:jackson-annotations:2.13.4:jar")
       dependency(id: "com.fasterxml.jackson.core:jackson-core:2.13.4:jar")
       dependency(id: "com.fasterxml.jackson.core:jackson-databind:2.13.4:jar")
-      dependency(id: "org.savantbuild:savant-utils:2.0.0-RC.7")
-      dependency(id: "org.savantbuild:savant-version:2.0.0-RC.7")
+      dependency(id: "org.savantbuild:savant-utils:${savantVersion}")
+      dependency(id: "org.savantbuild:savant-version:${savantVersion}")
     }
     group(name: "test-compile", export: false) {
       dependency(id: "org.testng:testng:6.8.7")
@@ -57,8 +58,8 @@ def release = loadPlugin(id: "org.savantbuild.plugin:release-git:2.0.0-RC.6")
 java.settings.javaVersion = "17"
 javaTestNG.settings.javaVersion = "17"
 idea.settings.moduleMap = [
-    "org.savantbuild:savant-utils:2.0.0-RC.7"  : "savant-utils",
-    "org.savantbuild:savant-version:2.0.0-RC.7": "savant-version"
+    ("org.savantbuild:savant-utils:${savantVersion}".toString())  : "savant-utils",
+    ("org.savantbuild:savant-version:${savantVersion}".toString()): "savant-version"
 ]
 
 target(name: "clean", description: "Cleans the project") {

--- a/build.savant
+++ b/build.savant
@@ -13,7 +13,7 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.0-RC.7", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.0", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/savant-dependency-management.iml
+++ b/savant-dependency-management.iml
@@ -12,7 +12,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="groovy-4.0.22" level="application" />
+    <orderEntry type="library" name="groovy-4.0" level="application" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>

--- a/savant-dependency-management.iml
+++ b/savant-dependency-management.iml
@@ -45,28 +45,8 @@
         </SOURCES>
       </library>
     </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-utils/2.0.0-RC.7/savant-utils-2.0.0-RC.7.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-utils/2.0.0-RC.7/savant-utils-2.0.0-RC.7-src.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-version/2.0.0-RC.7/savant-version-2.0.0-RC.7.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-version/2.0.0-RC.7/savant-version-2.0.0-RC.7-src.jar!/" />
-        </SOURCES>
-      </library>
-    </orderEntry>
+    <orderEntry type="module" module-name="savant-utils" />
+    <orderEntry type="module" module-name="savant-version" />
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>

--- a/savant-dependency-management.iml
+++ b/savant-dependency-management.iml
@@ -15,77 +15,77 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.4/jackson-databind-2.13.4.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.4/jackson-databind-2.13.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.4/jackson-databind-2.13.4-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.13.4/jackson-databind-2.13.4-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.13.4/jackson-annotations-2.13.4.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.13.4/jackson-annotations-2.13.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.13.4/jackson-annotations-2.13.4-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.13.4/jackson-annotations-2.13.4-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.13.4/jackson-core-2.13.4.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.13.4/jackson-core-2.13.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.13.4/jackson-core-2.13.4-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.13.4/jackson-core-2.13.4-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/org/savantbuild/savant-utils/2.0.0-RC.7/savant-utils-2.0.0-RC.7.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-utils/2.0.0-RC.7/savant-utils-2.0.0-RC.7.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/org/savantbuild/savant-utils/2.0.0-RC.7/savant-utils-2.0.0-RC.7-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-utils/2.0.0-RC.7/savant-utils-2.0.0-RC.7-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/org/savantbuild/savant-version/2.0.0-RC.7/savant-version-2.0.0-RC.7.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-version/2.0.0-RC.7/savant-version-2.0.0-RC.7.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/org/savantbuild/savant-version/2.0.0-RC.7/savant-version-2.0.0-RC.7-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/savantbuild/savant-version/2.0.0-RC.7/savant-version-2.0.0-RC.7-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/org/testng/testng/6.8.7/testng-6.8.7.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/6.8.7/testng-6.8.7.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/org/testng/testng/6.8.7/testng-6.8.7-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/6.8.7/testng-6.8.7-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/beust/jcommander/1.27.0/jcommander-1.27.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.27.0/jcommander-1.27.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/dev/os/savant/savant-dependency-management/.savant/cache/com/beust/jcommander/1.27.0/jcommander-1.27.0-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.27.0/jcommander-1.27.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/savant-dependency-management.iml
+++ b/savant-dependency-management.iml
@@ -12,7 +12,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="groovy-4.0" level="application" />
+    <orderEntry type="library" name="Groovy 4.0" level="application" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>
@@ -72,4 +72,3 @@
     </orderEntry>
   </component>
 </module>
-

--- a/savant-dependency-management.iml
+++ b/savant-dependency-management.iml
@@ -12,6 +12,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="groovy-4.0.22" level="application" />
     <orderEntry type="module-library">
       <library>
         <CLASSES>

--- a/src/main/java/org/savantbuild/dep/workflow/Workflow.java
+++ b/src/main/java/org/savantbuild/dep/workflow/Workflow.java
@@ -165,7 +165,7 @@ public class Workflow {
         // Publish the Savant named source JAR to prevent going back out to remote repositories next time we want to load source JARs
         if (file != null) {
           item = new ResolvableItem(artifact.id.group, artifact.id.project, artifact.id.name, artifact.version.toString(), artifact.getArtifactSourceFile());
-          publishWorkflow.publish(item, file);
+          file = publishWorkflow.publish(item, file);
         }
       }
 

--- a/src/main/java/org/savantbuild/dep/workflow/Workflow.java
+++ b/src/main/java/org/savantbuild/dep/workflow/Workflow.java
@@ -153,6 +153,7 @@ public class Workflow {
         // Publish the Savant named source JAR to prevent going back out to remote repositories next time we want to load source JARs
         if (file != null) {
           item = new ResolvableItem(artifact.id.group, artifact.id.project, artifact.id.name, artifact.version.toString(), artifact.getArtifactSourceFile());
+          // we should be returning our locally cached/published source path, not the remote source path
           return publishWorkflow.publish(item, file);
         }
       }

--- a/src/main/java/org/savantbuild/dep/workflow/Workflow.java
+++ b/src/main/java/org/savantbuild/dep/workflow/Workflow.java
@@ -154,7 +154,7 @@ public class Workflow {
         if (file != null) {
           item = new ResolvableItem(artifact.id.group, artifact.id.project, artifact.id.name, artifact.version.toString(), artifact.getArtifactSourceFile());
           // we should be returning our locally cached/published source path, not the remote source path
-          return publishWorkflow.publish(item, file);
+          file = publishWorkflow.publish(item, file);
         }
       }
 

--- a/src/main/java/org/savantbuild/dep/workflow/Workflow.java
+++ b/src/main/java/org/savantbuild/dep/workflow/Workflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.savantbuild.dep.ArtifactTools;
 import org.savantbuild.dep.domain.Artifact;
 import org.savantbuild.dep.domain.ArtifactMetaData;
 import org.savantbuild.dep.domain.ResolvableItem;
@@ -31,7 +32,6 @@ import org.savantbuild.dep.maven.MavenTools;
 import org.savantbuild.dep.maven.POM;
 import org.savantbuild.dep.workflow.process.NegativeCacheException;
 import org.savantbuild.dep.workflow.process.ProcessFailureException;
-import org.savantbuild.dep.ArtifactTools;
 import org.savantbuild.domain.Version;
 import org.savantbuild.domain.VersionException;
 import org.savantbuild.output.Output;
@@ -153,7 +153,7 @@ public class Workflow {
         // Publish the Savant named source JAR to prevent going back out to remote repositories next time we want to load source JARs
         if (file != null) {
           item = new ResolvableItem(artifact.id.group, artifact.id.project, artifact.id.name, artifact.version.toString(), artifact.getArtifactSourceFile());
-          publishWorkflow.publish(item, file);
+          return publishWorkflow.publish(item, file);
         }
       }
 

--- a/src/test/java/org/savantbuild/dep/workflow/process/WorkflowTest.java
+++ b/src/test/java/org/savantbuild/dep/workflow/process/WorkflowTest.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.assertTrue;
  */
 public class WorkflowTest extends BaseUnitTest {
   @Test
-  public void fetchSource_publish_no_process_exists() throws Exception {
+  public void fetchSource_publish_source_file_does_not_exist() throws Exception {
     // arrange
     Path cache = projectDir.resolve("build/test/cache");
     PathTools.prune(cache);
@@ -72,7 +72,7 @@ public class WorkflowTest extends BaseUnitTest {
   }
 
   @Test
-  public void fetchSource_publish_process_exists() throws Exception {
+  public void fetchSource_publish_source_file_exists() throws Exception {
     // arrange
     Path cache = projectDir.resolve("build/test/cache");
     PathTools.prune(cache);

--- a/src/test/java/org/savantbuild/dep/workflow/process/WorkflowTest.java
+++ b/src/test/java/org/savantbuild/dep/workflow/process/WorkflowTest.java
@@ -95,8 +95,8 @@ public class WorkflowTest extends BaseUnitTest {
     var sourcePath = workflow.fetchSource(artifact);
 
     // assert
-    // expect src, not sources, because both are fetched, and src is the "steady state"
-    // that we will get if we run this consistently
+    // expect src, not sources, because src is what will get published to the cache
+    // and that will result in less noisy output for things like the IDEA plugin
     assertEquals(sourcePath.toString(), "../savant-dependency-management/build/test/cache/org/apache/groovy/groovy/4.0.5/groovy-4.0.5-src.jar");
   }
 


### PR DESCRIPTION
Main objective here was to fix the `.iml` file noise. By that, I mean if you run `sb idea` with a fresh project (no savant cache), before this, you'd get slightly different source file paths than if you run it again, with everything cached. After this change, we return the published/cache file such that the IDEA plugin is more deterministic.

Related:
- https://github.com/savant-build/idea-plugin/pull/3