### PR TITLE
Improve performance when resolving maven artifacts using non-semantic versions

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 savantVersion = "2.0.0"
-project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.1", licenses: ["Apache-2.0"]) {
+project(group: "org.savantbuild", name: "savant-dependency-management", version: "2.0.2", licenses: ["Apache-2.0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/org/savantbuild/dep/workflow/process/DoNotPublishProcess.java
+++ b/src/main/java/org/savantbuild/dep/workflow/process/DoNotPublishProcess.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.savantbuild.dep.workflow.process;
+
+import java.nio.file.Path;
+
+import org.savantbuild.dep.domain.ResolvableItem;
+import org.savantbuild.dep.workflow.PublishWorkflow;
+
+/**
+ * Do not publish just return the provided item.
+ *
+ * @author Daniel DeGroff
+ */
+public class DoNotPublishProcess implements Process {
+  @Override
+  public Path fetch(ResolvableItem item, PublishWorkflow publishWorkflow) throws ProcessFailureException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Path publish(ResolvableItem item, Path itemFile) throws ProcessFailureException {
+    return itemFile;
+  }
+}


### PR DESCRIPTION
### Summary

1. Cache local version of the jar copied from the maven to avoid cache miss.
2. Do not publish maven artifacts, only the pom which is needed to map to the semantic versioned artifacts

### Related